### PR TITLE
Sets isRuntimeContext to true before asking for fields

### DIFF
--- a/src/main/generate.mjs
+++ b/src/main/generate.mjs
@@ -28,6 +28,9 @@ export const prepareFolder = async (path, tempNames, logger, appName = 'appName'
       // Get the template variables and return them here, if the template has a generator
       if (template.Generator && typeof template.Generator === 'function') {
         const gen = new template.Generator()
+        gen.setConfig({
+          isRuntimeContext: true
+        })
         templateVariables[name] = gen.getConfigFieldsDefinitions()
       }
     }


### PR DESCRIPTION
Service should not expose fields if `isRuntimeContext == true`

Refs: https://github.com/platformatic/platformatic/pull/1873