### PR TITLE
feature/adding-info-in-case-import-works

### DIFF
--- a/src/main/lib/import-or-local.mjs
+++ b/src/main/lib/import-or-local.mjs
@@ -6,7 +6,10 @@ import { runCommand } from './run-command.mjs'
 
 async function importOrLocal ({ pkgManager, projectDir, pkg, logger }) {
   try {
-    return await import(pkg)
+    logger.info(`Installing ${pkg} on ${projectDir}...`)
+    await import(pkg)
+    logger.info(`During installation we found that there are upper folders with node_modules installed or there is a global installation.`)
+    return null
   } catch (err) {
     // This file does not need to exists, will be created automatically
     const pkgJsonPath = path.join(projectDir, 'package.json')
@@ -16,8 +19,6 @@ async function importOrLocal ({ pkgManager, projectDir, pkg, logger }) {
       const fileToImport = _require.resolve(pkg)
       return await import(pathToFileURL(fileToImport))
     } catch (err) {}
-
-    logger.info(`Installing ${pkg} on ${projectDir}...`)
 
     const child = runCommand(pkgManager, ['install', pkg], { cwd: projectDir })
 

--- a/src/main/lib/import-or-local.mjs
+++ b/src/main/lib/import-or-local.mjs
@@ -8,7 +8,7 @@ async function importOrLocal ({ pkgManager, projectDir, pkg, logger }) {
   try {
     logger.info(`Installing ${pkg} on ${projectDir}...`)
     await import(pkg)
-    logger.info(`During installation we found that there are upper folders with node_modules installed or there is a global installation.`)
+    logger.info('During installation we found that there are upper folders with node_modules installed or there is a global installation.')
     return null
   } catch (err) {
     // This file does not need to exists, will be created automatically


### PR DESCRIPTION
Hi @mcollina 

thanks to @marcopiraccini 🍻 we found that 
- if a user select a folder that is inside a folder tree where he already had a node_modules installed, the folder that he selected is not prepared and he can continue the installation of the app
- same stuff if you have platformatic installed globally.

this is what the user will see

![image](https://github.com/platformatic/meraki/assets/25035977/efc2f2bc-f953-4ffc-a459-cebf2c5bf5e4)
