### PR TITLE
fix: problem to leave the service without name

### DIFF
--- a/src/renderer/src/components/steps/compose-application/ComposeApplication.jsx
+++ b/src/renderer/src/components/steps/compose-application/ComposeApplication.jsx
@@ -208,7 +208,7 @@ const ComposeApplication = React.forwardRef(({ onNext, onBack }, ref) => {
         />
 
         <Button
-          disabled={!(Object.hasOwn(services[0]?.template, 'name'))}
+          disabled={services.find(service => (service.template?.name ?? '') === '')}
           label='Next - Prepare Folder'
           onClick={() => onClickPrepareFolder()}
           color={RICH_BLACK}


### PR DESCRIPTION
Hi @ivan-tymoshenko @Fmusso94 

Right now, when a user click on Add Template, and then clicks on Select Template., under the hoods occurs two separate things. For have instead only one action (user clicks on addTemplate and he can choose immediately the template from the lefty modal), I should rework some stuff on the React Store and on some UI. Right now, to avoid the problem to have a service without a template I created this PR (loom below of how works).

https://www.loom.com/share/7a7a1deefa09467c85bc8921c833b817