### PR TITLE
Start runtime fix

### DIFF
--- a/src/main/index.mjs
+++ b/src/main/index.mjs
@@ -235,8 +235,9 @@ app.whenReady().then(async () => {
     return appApis.deleteApplication(id)
   })
 
-  ipcMain.handle('start-app', async (_, id) => {
-    return appApis.startRuntime(id)
+  ipcMain.handle('start-app', async (_, appId) => {
+    const { id, url } = appApis.startRuntime(appId)
+    return { id, url }
   })
 
   ipcMain.handle('stop-app', async (_, id) => {

--- a/src/main/lib/run-npm.mjs
+++ b/src/main/lib/run-npm.mjs
@@ -1,66 +1,11 @@
 'use strict'
 
-import { access } from 'node:fs/promises'
 import execa from 'execa'
 import { app } from 'electron'
 import split from 'split2'
 import { dirname } from 'node:path'
-import { homedir } from 'node:os'
 import log from 'electron-log'
-
-async function isFileAccessible (filename) {
-  try {
-    await access(filename)
-    return true
-  } catch (err) {
-    return false
-  }
-}
-
-async function findNpmInShellPath () {
-  const DEFAULT_SHELL = process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash'
-  const currentShell = process.env.SHELL || DEFAULT_SHELL
-  const homeDir = homedir()
-  let sourceFile = `${homeDir}/.zshrc`
-  if (currentShell === '/bin/bash') {
-    sourceFile = `${homeDir}/bashrc`
-  }
-
-  // we need homebrew because in some `.zshrc` files, there are references to binaries installed by homebrew
-  // and we need to make sure that those binaries are in the PATH
-  const options = {
-    env: {
-      PATH: '/usr/bin:/bin:/usr/local/bin:/sbin:/usr/sbin:/opt/homebrew/bin'
-    }
-  }
-  let binPath = null
-  try {
-    const { stdout } = await execa(currentShell, ['-c', `. ${sourceFile}; which npm`], options)
-    binPath = stdout?.trim()
-    log.info(`Found npm in PATH after sourcing ${sourceFile}: ${binPath}`)
-  } catch (err) {
-    log.warn(`Error finding npm in PATH after sourcing ${sourceFile}: ${err.message}`)
-  }
-  return binPath
-}
-
-async function findNpmExec () {
-  const npmInPath = await findNpmInShellPath()
-  if (npmInPath === null) {
-    const paths = [
-      '/usr/local/bin/npm',
-      '/usr/bin/npm',
-      '/bin/npm'
-    ]
-    for (const location of paths) {
-      if (await isFileAccessible(location)) {
-        return location
-      }
-    }
-    return null
-  }
-  return npmInPath
-}
+import { findExecutable } from './utils.mjs'
 
 async function npmInstall (pkg = null, options, logger) {
   const installOptions = ['install']
@@ -74,7 +19,7 @@ async function npmInstall (pkg = null, options, logger) {
     child = execa('npm', installOptions, options)
   } else {
     // OSx and linux
-    const executable = await findNpmExec()
+    const executable = await findExecutable('npm')
     if (executable === null) {
       throw new Error('Cannot find npm executable')
     }

--- a/src/main/lib/utils.mjs
+++ b/src/main/lib/utils.mjs
@@ -1,6 +1,10 @@
 import { app } from 'electron'
 import { basename, dirname, resolve } from 'node:path'
+import { access } from 'node:fs/promises'
 import { request } from 'undici'
+import { homedir } from 'node:os'
+import log from 'electron-log'
+import execa from 'execa'
 
 const isMac = process.platform === 'darwin'
 
@@ -20,6 +24,15 @@ const getAppPath = () => {
   return rootDir
 }
 
+async function isFileAccessible (filename) {
+  try {
+    await access(filename)
+    return true
+  } catch (err) {
+    return false
+  }
+}
+
 async function getLatestPlatformaticVersion (pkg) {
   const res = await request('https://registry.npmjs.org/platformatic')
   if (res.statusCode === 200) {
@@ -29,4 +42,49 @@ async function getLatestPlatformaticVersion (pkg) {
   return null
 }
 
-export { getAppPath, getLatestPlatformaticVersion }
+async function findExecutableInShellPath (executableName) {
+  const DEFAULT_SHELL = process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash'
+  const currentShell = process.env.SHELL || DEFAULT_SHELL
+  const homeDir = homedir()
+  let sourceFile = `${homeDir}/.zshrc`
+  if (currentShell === '/bin/bash') {
+    sourceFile = `${homeDir}/bashrc`
+  }
+
+  // we need homebrew because in some `.zshrc` files, there are references to binaries installed by homebrew
+  // and we need to make sure that those binaries are in the PATH
+  const options = {
+    env: {
+      PATH: '/usr/bin:/bin:/usr/local/bin:/sbin:/usr/sbin:/opt/homebrew/bin'
+    }
+  }
+  let binPath = null
+  try {
+    const { stdout } = await execa(currentShell, ['-c', `. ${sourceFile}; which ${executableName}`], options)
+    binPath = stdout?.trim()
+    log.info(`Found ${executableName} in PATH after sourcing ${sourceFile}: ${binPath}`)
+  } catch (err) {
+    log.warn(`Error finding ${executableName} in PATH after sourcing ${sourceFile}: ${err.message}`)
+  }
+  return binPath
+}
+
+async function findExecutable (executableName) {
+  const execInPath = await findExecutableInShellPath(executableName)
+  if (execInPath === null) {
+    const paths = [
+      `/usr/local/bin/${executableName}`,
+      `/usr/bin/${executableName}`,
+      `/bin/${executableName}`
+    ]
+    for (const location of paths) {
+      if (await isFileAccessible(location)) {
+        return location
+      }
+    }
+    return null
+  }
+  return execInPath
+}
+
+export { getAppPath, getLatestPlatformaticVersion, findExecutable, isFileAccessible }


### PR DESCRIPTION
This is necessary because `process.execPath` in electron is...`electron` and not `node`. 
Also refactored the code to share the same functions to find `npm` and `node`. 