### PR TITLE
Skip sign on windows when releasing a draft

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -68,6 +68,7 @@ jobs:
         shell: bash
 
       - name: Setup Keylocker KSP on windows 
+        if: ${{ input.apply_win_sign == 'true'}}
         run: | 
           curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/Keylockertools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o Keylockertools-windows-x64.msi 
           msiexec /i Keylockertools-windows-x64.msi /quiet /qn
@@ -77,11 +78,13 @@ jobs:
         shell: cmd 
       
       - name: Certificates Sync       
+        if: ${{ input.apply_win_sign == 'true'}}
         run: |
           smctl windows certsync
         shell: cmd
 
       - name: SMCTL healthcheck
+        if: ${{ input.apply_win_sign == 'true'}}
         run: |
           smctl healthcheck
         shell: cmd 

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -48,7 +48,7 @@ jobs:
       SM_API_KEY: ${{ secrets.SM_API_KEY }}
       SM_CLIENT_CERT_FILE: D:\\Certificate_pkcs12.p12
       SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
-      APPLY_WIN_SIGN: ${{ input.apply_win_sign }}
+      APPLY_WIN_SIGN: ${{ inputs.apply_win_sign }}
     steps:
       - run: echo "Creating Windows release for tag ${{ inputs.tag_name }}"
       - name: Set up certificate 
@@ -68,7 +68,7 @@ jobs:
         shell: bash
 
       - name: Setup Keylocker KSP on windows 
-        if: ${{ input.apply_win_sign == 'true'}}
+        if: ${{ inputs.apply_win_sign == 'true'}}
         run: | 
           curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/Keylockertools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o Keylockertools-windows-x64.msi 
           msiexec /i Keylockertools-windows-x64.msi /quiet /qn
@@ -78,13 +78,13 @@ jobs:
         shell: cmd 
       
       - name: Certificates Sync       
-        if: ${{ input.apply_win_sign == 'true'}}
+        if: ${{ inputs.apply_win_sign == 'true'}}
         run: |
           smctl windows certsync
         shell: cmd
 
       - name: SMCTL healthcheck
-        if: ${{ input.apply_win_sign == 'true'}}
+        if: ${{ inputs.apply_win_sign == 'true'}}
         run: |
           smctl healthcheck
         shell: cmd 

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -6,6 +6,10 @@ on:
     inputs:
       tag_name:
         type: string
+      apply_win_sign:
+        type: boolean
+        default: false
+
   push:
     branches:
       - main
@@ -44,6 +48,7 @@ jobs:
       SM_API_KEY: ${{ secrets.SM_API_KEY }}
       SM_CLIENT_CERT_FILE: D:\\Certificate_pkcs12.p12
       SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+      APPLY_WIN_SIGN: ${{ input.apply_win_sign }}
     steps:
       - run: echo "Creating Windows release for tag ${{ inputs.tag_name }}"
       - name: Set up certificate 

--- a/.github/workflows/release-version-bump.yml
+++ b/.github/workflows/release-version-bump.yml
@@ -46,6 +46,7 @@ jobs:
     uses: platformatic/meraki/.github/workflows/release-draft.yml@main
     with:
       tag_name: ${{ needs.prepare-release.outputs.TAG }}
+      apply_win_sign: true
     secrets: inherit
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
     uses: platformatic/meraki/.github/workflows/release-draft.yml@main
     with:
       tag_name: ${{ needs.prepare-release.outputs.TAG }}
+      apply_win_sign: true
     secrets: inherit
 
   release:

--- a/sign-win.js
+++ b/sign-win.js
@@ -6,6 +6,13 @@ const { spawnSync } = require('child_process')
 // because we want to use the DigiCert signing tool to sign the executable.
 // See also: https://docs.digicert.com/en/digicert-keylocker/sign-with-digicert-signing-tools/sign-with-smctl.html
 exports.default = async function (configuration) {
+  const applySign = process.env.APPLY_WIN_SIGN === 'true'
+
+  if (!applySign) {
+    console.log('@@@@@@@@@@@@@@@@@@@@@@ APPLY_WIN_SIGN not set to true, skipping signing in windows')
+    return
+  }
+
   console.log('Signing: ', configuration.path)
   const execPath = configuration.path
 


### PR DESCRIPTION
Digicert put a limit to 1000 signatures to the certificate, so we need to limit the sign only for actual releases and not on every draft we create on merge on `main`