### PR TITLE
fix: wrong size icon running on all apps

### DIFF
--- a/src/renderer/src/components/applications/all/Row.jsx
+++ b/src/renderer/src/components/applications/all/Row.jsx
@@ -60,7 +60,7 @@ function Row ({
       return (
         <div className={`${styles.containerRunning} ${commonStyles.smallButtonSquarePadding}`}>
           <div className={styles.clockWiseRotation}>
-            <Icons.RunningIcon size={SMALL} color={WHITE} />
+            <Icons.RunningIcon size={MEDIUM} color={WHITE} />
           </div>
         </div>
       )


### PR DESCRIPTION
HI @marcopiraccini 

bug that cause a weird redimension on the start of All Apps

https://github.com/platformatic/meraki/assets/25035977/c6c8d432-93ec-46ad-ad84-7eec0d4c7a1b

