### PR TITLE
Disable Scalar sidebar

### DIFF
--- a/src/renderer/src/components/Scalar.jsx
+++ b/src/renderer/src/components/Scalar.jsx
@@ -18,7 +18,8 @@ export default function Scalar ({ url }) {
         customCss,
         spec: {
           url: `${url}/documentation/json`
-        }
+        },
+        showSidebar: false
       }}
     />
   )


### PR DESCRIPTION
We are temporary disabling the sidebar because the links on sidebar are not correct. 