### PR TITLE
Set the entrypoint in app update

### DIFF
--- a/src/main/generate.mjs
+++ b/src/main/generate.mjs
@@ -153,14 +153,18 @@ export const createApp = async (dir, { projectName, services, entrypoint, port, 
     }
   }
 
-  generator.setEntryPoint(entrypoint)
   if (!isUpdate) {
     // Creation
+    generator.setEntryPoint(entrypoint)
     await generator.prepare()
     await generator.writeFiles()
   } else {
     await generator.loadFromDir()
-    generator.update({ services })
+    await generator.update({ services })
+    generator.setEntryPoint(entrypoint)
+    // We need to call this twice becasue the `setEntryPoint` fails if the service is "uknonwn".
+    // This is basically a workaround for a bug in the runtime,
+    await generator.update({ services })
   }
 
   await npmInstall(null, { cwd: projectDir }, logger)

--- a/src/main/generate.mjs
+++ b/src/main/generate.mjs
@@ -153,9 +153,9 @@ export const createApp = async (dir, { projectName, services, entrypoint, port, 
     }
   }
 
+  generator.setEntryPoint(entrypoint)
   if (!isUpdate) {
     // Creation
-    generator.setEntryPoint(entrypoint)
     await generator.prepare()
     await generator.writeFiles()
   } else {

--- a/src/main/generate.mjs
+++ b/src/main/generate.mjs
@@ -160,11 +160,7 @@ export const createApp = async (dir, { projectName, services, entrypoint, port, 
     await generator.writeFiles()
   } else {
     await generator.loadFromDir()
-    await generator.update({ services })
-    generator.setEntryPoint(entrypoint)
-    // We need to call this twice becasue the `setEntryPoint` fails if the service is "uknonwn".
-    // This is basically a workaround for a bug in the runtime,
-    await generator.update({ services })
+    await generator.update({ services, entrypoint })
   }
 
   await npmInstall(null, { cwd: projectDir }, logger)

--- a/test/fixtures/runtime/platformatic.json
+++ b/test/fixtures/runtime/platformatic.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://platformatic.dev/schemas/v1.22.0/runtime",
   "entrypoint": "service-1",
-  "allowCycles": true,
   "hotReload": false,
   "autoload": {
     "path": "./services"

--- a/test/fixtures/runtime/services/service-2/platformatic.json
+++ b/test/fixtures/runtime/services/service-2/platformatic.json
@@ -4,6 +4,8 @@
     "openapi": true
   },
   "plugins": {
-    "paths": ["plugin.js"]
+    "paths": [
+      "plugin.js"
+    ]
   }
 }

--- a/test/main/create-app.test.mjs
+++ b/test/main/create-app.test.mjs
@@ -61,7 +61,7 @@ test('Create app with no entrypoint should fail', async () => {
   }
 }, 20000)
 
-test('Create app', async (t) => {
+test('Create app', async () => {
   const appDir = await mkdtemp(join(tmpdir(), 'plat-app-test-create'))
   onTestFinished(() => rm(appDir, { recursive: true }))
   const project = {
@@ -112,6 +112,7 @@ test('Create app', async (t) => {
       expect(await isFileAccessible(join(appDir, file)))
     }
   } catch (err) {
-    test.fails('Should have not thrown an error')
+    console.error(err)
+    throw err
   }
 }, 60000)

--- a/test/main/update-app.test.mjs
+++ b/test/main/update-app.test.mjs
@@ -139,11 +139,6 @@ test('Create app then update it, changing the entrypoint', async (t) => {
   expect(services).toHaveLength(1)
   expect(services).toContain('electron-testing-1')
 
-  // We copy a file to the services folder, the upgrade
-  // should just ignore it
-  const serviceFile = join(appDir, projectName, 'services', 'ignoreme')
-  await writeFile(serviceFile, 'ignoreme')
-
   project.services.push({
     name: 'electron-testing-2',
     template: '@platformatic/service',
@@ -156,8 +151,7 @@ test('Create app then update it, changing the entrypoint', async (t) => {
   await createApp(appDir, project, logger, true)
 
   services = await readdir(join(appDir, projectName, 'services'))
-  expect(services).toHaveLength(3)
-  expect(services).toContain('ignoreme')
+  expect(services).toHaveLength(2)
   expect(services).toContain('electron-testing-2')
   expect(services).toContain('electron-testing-1')
 

--- a/test/main/update-app.test.mjs
+++ b/test/main/update-app.test.mjs
@@ -2,7 +2,7 @@ import { test, beforeEach, onTestFinished, expect } from 'vitest'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createApp } from '../../src/main/generate.mjs'
-import { mkdtemp, rm, writeFile, readdir } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile, readdir, readFile } from 'node:fs/promises'
 const logger = {
   infos: [],
   errors: [],
@@ -23,6 +23,76 @@ beforeEach(() => {
 })
 
 test('Create app then update it', async (t) => {
+  const appDir = await mkdtemp(join(tmpdir(), 'plat-app-test-create'))
+  // onTestFinished(() => rm(appDir, { recursive: true }))
+  const projectName = 'testapp'
+  const project = {
+    projectName,
+    services: [
+      {
+        name: 'electron-testing-1',
+        template: '@platformatic/service',
+        fields: [
+          {
+            var: 'PLT_SERVER_HOSTNAME',
+            value: '125.500.500.0',
+            configValue: 'hostname',
+            type: 'string'
+          },
+          {
+            var: 'PLT_SERVER_LOGGER_LEVEL',
+            value: 'boh',
+            configValue: '',
+            type: 'string'
+          },
+          {
+            var: 'PORT',
+            value: '111111',
+            configValue: 'port'
+          }
+        ],
+        plugins: []
+      }
+    ],
+
+    entrypoint: 'electron-testing-1',
+    port: '12312',
+    logLevel: 'trace',
+    typescript: true,
+    createGitHubRepository: true,
+    installGitHubAction: true
+  }
+
+  await createApp(appDir, project, logger)
+
+  let services = await readdir(join(appDir, projectName, 'services'))
+  expect(services).toHaveLength(1)
+  expect(services).toContain('electron-testing-1')
+
+  // We copy a file to the services folder, the upgrade
+  // should just ignore it
+  const serviceFile = join(appDir, projectName, 'services', 'ignoreme')
+  await writeFile(serviceFile, 'ignoreme')
+
+  project.services.push({
+    name: 'electron-testing-2',
+    template: '@platformatic/service',
+    fields: [],
+    plugins: []
+  })
+  project.entrypoint = 'electron-testing-1'
+
+  // We update it
+  await createApp(appDir, project, logger, true)
+
+  services = await readdir(join(appDir, projectName, 'services'))
+  expect(services).toHaveLength(3)
+  expect(services).toContain('ignoreme')
+  expect(services).toContain('electron-testing-2')
+  expect(services).toContain('electron-testing-1')
+}, 60000)
+
+test('Create app then update it, changing the entrypoint', async (t) => {
   const appDir = await mkdtemp(join(tmpdir(), 'plat-app-test-create'))
   onTestFinished(() => rm(appDir, { recursive: true }))
   const projectName = 'testapp'
@@ -80,6 +150,7 @@ test('Create app then update it', async (t) => {
     fields: [],
     plugins: []
   })
+  project.entrypoint = 'electron-testing-2'
 
   // We update it
   await createApp(appDir, project, logger, true)
@@ -89,4 +160,7 @@ test('Create app then update it', async (t) => {
   expect(services).toContain('ignoreme')
   expect(services).toContain('electron-testing-2')
   expect(services).toContain('electron-testing-1')
+
+  const config = await readFile(join(appDir, projectName, 'platformatic.json'), 'utf8')
+  expect(JSON.parse(config).entrypoint).toBe('electron-testing-2')
 }, 60000)


### PR DESCRIPTION
One test is failing for a Platformatic bug (the entrypoint is update is not really changed by the generator). So DON'T MERGE until the fix is released in Platformatic. 